### PR TITLE
第一类 Chebyshev 多项式的正交性

### DIFF
--- a/数值算法与案例分析II/2 插值.ipynb
+++ b/数值算法与案例分析II/2 插值.ipynb
@@ -321,7 +321,24 @@
     "\n",
     "#### 正交性\n",
     "\n",
-    "$$\\int_{-1}^1 \\frac{T_n(x)T_m(x)}{\\sqrt{1 - x^2}}dx = \\frac{\\pi}{2}\\delta_{nm}$$"
+    "$$\\begin{align}\n",
+    "\\int_{-1}^1 \\frac{T_m(x)T_n(x)}{\\sqrt{1-x^2}} {\\mathrm d}x\n",
+    "&= \\int_0^\\pi \\cos{[m \\arccos(x)]} \\cos{[n\\arccos(x)]} {\\mathrm d}\\arccos(x)\\quad (\\text{denote }\\theta:= \\arccos(x))\\\\\n",
+    "&= \\int_0^\\pi \\cos(m\\theta)\\cos(n\\theta) {\\mathrm d\\theta} \\\\\n",
+    "&= \\frac12 \\int_{0}^\\pi \\cos((m-n)\\theta) {\\mathrm d}\\theta \n",
+    "+ \\frac12 \\int_{0}^\\pi \\cos((m+n)\\theta) {\\mathrm d}\\theta\n",
+    "\\quad \\left(\\text{note that }\\int_0^\\pi \\cos(k\\pi) {\\mathrm d}\\theta = \n",
+    "\\begin{cases}\n",
+    "1, &k=0\\\\\n",
+    "0, &k\\neq 0\n",
+    "\\end{cases}\\right)\\\\\n",
+    "&= \n",
+    "\\begin{cases}\n",
+    "\\pi, & m=n=0\\\\\n",
+    "\\frac{\\pi}{2}, & m=n\\neq 0\\\\\n",
+    "0, & m\\neq n\n",
+    "\\end{cases}\n",
+    "\\end{align}$$\n"
    ]
   },
   {

--- a/数值算法与案例分析II/2 插值.ipynb
+++ b/数值算法与案例分析II/2 插值.ipynb
@@ -323,7 +323,7 @@
     "\n",
     "$$\\begin{align}\n",
     "\\int_{-1}^1 \\frac{T_m(x)T_n(x)}{\\sqrt{1-x^2}} {\\mathrm d}x\n",
-    "&= \\int_0^\\pi \\cos{[m \\arccos(x)]} \\cos{[n\\arccos(x)]} {\\mathrm d}\\arccos(x)\\quad (\\text{denote }\\theta:= \\arccos(x))\\\\\n",
+    "&= \\int_{-1}^{1} \\cos{[m \\arccos(x)]} \\cos{[n\\arccos(x)]} {\\mathrm d}\\arccos(x)\\quad (\\text{denote }\\theta:= \\arccos(x))\\\\\n",
     "&= \\int_0^\\pi \\cos(m\\theta)\\cos(n\\theta) {\\mathrm d\\theta} \\\\\n",
     "&= \\frac12 \\int_{0}^\\pi \\cos((m-n)\\theta) {\\mathrm d}\\theta \n",
     "+ \\frac12 \\int_{0}^\\pi \\cos((m+n)\\theta) {\\mathrm d}\\theta\n",


### PR DESCRIPTION
学长你好! 我在数值2的笔记中发现一个不严谨的地方.
在第一类 Chebyshev 多项式的正交性中，
m = n 的情况可能需要分 m = n = 0 和 m = n \neq 0 讨论，前者内积结果是 \pi, 而后者内积结果是 \pi/2.
这样就不能直接用 \frac{\pi}{2}\delta_{nm} 来表示了.